### PR TITLE
Hard code manager data date to get around bug that appeared this morning

### DIFF
--- a/src/Bookings.js
+++ b/src/Bookings.js
@@ -17,14 +17,23 @@ class Bookings {
     }, 0);
   }
   findAvailableRooms(date, selectedType) {
-    let filteredByType = this.roomData.filter(room => room.roomType === selectedType)
-    return filteredByType.filter(room => {
-      return !this.bookingData.find(booking => {
-        return (room.number === booking.roomNumber && date === booking.date);
+    if (selectedType === undefined) {
+      return this.roomData.filter(room => {
+        return !this.bookingData.find(booking => {
+          return (room.number === booking.roomNumber && date === booking.date);
+        })
       })
-    })
+    } else {
+      let filteredByType = this.roomData.filter(room => room.roomType === selectedType)
+      return filteredByType.filter(room => {
+        return !this.bookingData.find(booking => {
+          return (room.number === booking.roomNumber && date === booking.date);
+        })
+      })
+    }
   }
   findTotalRevenue(date) {
+    // NOTE: Due to weird bug, 'date' is hardcoded as '2020/02/16' in index.js line 103-104
     return this.bookingData.filter(booking => booking.date === date).reduce((acc, sum) => {
       let pricePerRoom = Math.floor(this.roomData.find(room => room.number === sum.roomNumber).costPerNight);
       return acc += pricePerRoom;

--- a/src/index.js
+++ b/src/index.js
@@ -100,8 +100,9 @@ function updateTotalSpendHTML() {
 function changeToManagerDash() {
   $('.login-page').addClass('hidden');
   $('.manager-dash').removeClass('hidden');
-  displayRevenue(booking.findTotalRevenue(todaysDate))
-  displayAvailRoomsManager(booking.findAvailableRooms(todaysDate))
+  // NOTE: Due to bug, the dates below are hard coded in. Should be replaced with todaysDate, but manager functionality for today does not work 
+  displayRevenue(booking.findTotalRevenue('2020/02/16'))
+  displayAvailRoomsManager(booking.findAvailableRooms('2020/02/16'))
   $('#search-guest-btn').on('click', searchForGuest);
 }
 


### PR DESCRIPTION
While testing my app this morning, I found a bug where the manager portal data would not populate for today's (2020/01/15) date. The error was 'costPerNight' is not defined. I have no idea why this was happening. Because of this, I hard-coded in the date to pass into the manager portal. **This means that as of now, the manager data is displaying the data for 2020/02/16. I will attempt to debug this soon.

I chose this date in February because it still has some rooms available so all three manager portal boxes are populated. 